### PR TITLE
Extract menu parsing logic and add unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         run: npx playwright install --with-deps
       - name: Run ESLint
         run: npm run lint
+      - name: Run unit tests
+        run: npm test
     # - name: Run Playwright tests
     # run: npx playwright test
     # - uses: actions/upload-artifact@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "prettier": "^3.3.1",
         "prettier-eslint": "^16.3.0",
         "prisma": "^5.19.1",
+        "tsx": "^4.23.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8"
       }
@@ -656,6 +657,448 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -4620,6 +5063,48 @@
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -10107,6 +10592,40 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint .",
+    "test": "tsx --test src/lib/**/*.test.ts",
     "playwright-development": "npx playwright test",
     "playwright-ci": "next dev && npx playwright test"
   },
@@ -70,6 +71,7 @@
     "prettier": "^3.3.1",
     "prettier-eslint": "^16.3.0",
     "prisma": "^5.19.1",
+    "tsx": "^4.23.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8"
   }

--- a/src/lib/ccMenuParsing.test.ts
+++ b/src/lib/ccMenuParsing.test.ts
@@ -1,0 +1,315 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+import {
+  collectCandidatesFromDom,
+  collectCandidatesFromEmbeddedJson,
+  createMenuCandidate,
+  findCurrentWeekMenu,
+  isTodayWithinRange,
+  mergeMenuCandidates,
+  normalizePdfHref,
+  parseMenuDateRange,
+} from './ccMenuParsing';
+import type { DateParts, MenuCandidate } from './ccMenuParsing';
+
+const julySix2026: DateParts = { year: 2026, month: 6, day: 6 };
+const julyEleven2026: DateParts = { year: 2026, month: 6, day: 11 };
+
+function assertDate(date: Date, year: number, month: number, day: number): void {
+  assert.equal(date.getFullYear(), year);
+  assert.equal(date.getMonth(), month);
+  assert.equal(date.getDate(), day);
+}
+
+function makeCandidate(
+  label: string,
+  href: string,
+  startYear: number,
+  startMonth: number,
+  startDay: number,
+  endYear: number,
+  endMonth: number,
+  endDay: number,
+): MenuCandidate {
+  return {
+    label,
+    href,
+    startDate: new Date(startYear, startMonth, startDay),
+    endDate: new Date(endYear, endMonth, endDay),
+  };
+}
+
+describe('parseMenuDateRange', () => {
+  it('parses the primary day-month format', () => {
+    const parsed = parseMenuDateRange(
+      'Campus Center Food Court Menu 06 July to 10 July',
+      julySix2026,
+    );
+
+    assert.ok(parsed);
+    assert.equal(parsed.format, 'day-month');
+    assertDate(parsed.startDate, 2026, 6, 6);
+    assertDate(parsed.endDate, 2026, 6, 10);
+  });
+
+  it('parses abbreviated months and hyphen separators', () => {
+    const parsed = parseMenuDateRange(
+      'Campus Center Food Court Menu 03 Mar to 09 Mar',
+      { year: 2026, month: 2, day: 5 },
+    );
+
+    assert.ok(parsed);
+    assert.equal(parsed.format, 'day-month');
+    assertDate(parsed.startDate, 2026, 2, 3);
+    assertDate(parsed.endDate, 2026, 2, 9);
+  });
+
+  it('parses en-dash, em-dash, and ordinal suffixes', () => {
+    const dashParsed = parseMenuDateRange(
+      'Campus Center Food Court Menu 29 June – 03 July',
+      julySix2026,
+    );
+    const ordinalParsed = parseMenuDateRange(
+      'Campus Center Food Court Menu 6th July to 10th July',
+      julySix2026,
+    );
+
+    assert.ok(dashParsed);
+    assertDate(dashParsed.startDate, 2026, 5, 29);
+    assertDate(dashParsed.endDate, 2026, 6, 3);
+
+    assert.ok(ordinalParsed);
+    assert.equal(ordinalParsed.format, 'day-month');
+    assertDate(ordinalParsed.startDate, 2026, 6, 6);
+    assertDate(ordinalParsed.endDate, 2026, 6, 10);
+  });
+
+  it('parses month-day format as a secondary parser', () => {
+    const parsed = parseMenuDateRange(
+      'Campus Center Food Court Menu July 6 to July 10',
+      julySix2026,
+    );
+
+    assert.ok(parsed);
+    assert.equal(parsed.format, 'month-day');
+    assertDate(parsed.startDate, 2026, 6, 6);
+    assertDate(parsed.endDate, 2026, 6, 10);
+  });
+
+  it('parses numeric month/day format as a secondary parser', () => {
+    const parsed = parseMenuDateRange(
+      'Campus Center Food Court Menu 7/6 to 7/10',
+      julySix2026,
+    );
+
+    assert.ok(parsed);
+    assert.equal(parsed.format, 'numeric');
+    assertDate(parsed.startDate, 2026, 6, 6);
+    assertDate(parsed.endDate, 2026, 6, 10);
+  });
+
+  it('parses numeric ranges with explicit years', () => {
+    const parsed = parseMenuDateRange(
+      'Campus Center Food Court Menu 07/06/2026 to 07/10/2026',
+      julySix2026,
+    );
+
+    assert.ok(parsed);
+    assert.equal(parsed.format, 'numeric');
+    assertDate(parsed.startDate, 2026, 6, 6);
+    assertDate(parsed.endDate, 2026, 6, 10);
+  });
+
+  it('parses ISO date ranges as a secondary parser', () => {
+    const parsed = parseMenuDateRange(
+      'Campus Center Food Court Menu 2026-07-06 to 2026-07-10',
+      julySix2026,
+    );
+
+    assert.ok(parsed);
+    assert.equal(parsed.format, 'iso');
+    assertDate(parsed.startDate, 2026, 6, 6);
+    assertDate(parsed.endDate, 2026, 6, 10);
+  });
+
+  it('handles year-boundary ranges that cross December and January', () => {
+    const parsed = parseMenuDateRange(
+      'Campus Center Food Court Menu 29 Dec to 02 Jan',
+      { year: 2026, month: 0, day: 1 },
+    );
+
+    assert.ok(parsed);
+    assertDate(parsed.startDate, 2025, 11, 29);
+    assertDate(parsed.endDate, 2026, 0, 2);
+  });
+
+  it('returns null for unsupported labels', () => {
+    assert.equal(parseMenuDateRange('Campus Center Food Court Menu', julySix2026), null);
+    assert.equal(parseMenuDateRange('No dates here at all', julySix2026), null);
+    assert.equal(parseMenuDateRange('Campus Center Food Court Menu Mon 6 Jul - Fri 10 Jul', julySix2026), null);
+  });
+});
+
+describe('normalizePdfHref', () => {
+  it('prefixes relative Sodexo media paths', () => {
+    assert.equal(
+      normalizePdfHref('/web/en-us/media/menu_tcm17-89982.pdf'),
+      'https://media-prd.sodexomyway.net/web/en-us/media/menu_tcm17-89982.pdf',
+    );
+  });
+
+  it('leaves absolute URLs unchanged', () => {
+    const absolute = 'https://media-prd.sodexomyway.net/web/en-us/media/menu.pdf';
+    assert.equal(normalizePdfHref(absolute), absolute);
+  });
+});
+
+describe('findCurrentWeekMenu', () => {
+  const candidates = [
+    makeCandidate(
+      'Campus Center Food Court Menu 29 June to 03 July',
+      'https://example.com/june.pdf',
+      2026, 5, 29, 2026, 6, 3,
+    ),
+    makeCandidate(
+      'Campus Center Food Court Menu 06 July to 10 July',
+      'https://example.com/july.pdf',
+      2026, 6, 6, 2026, 6, 10,
+    ),
+    makeCandidate(
+      'Campus Center Food Court Menu 13 July to 17 July',
+      'https://example.com/next.pdf',
+      2026, 6, 13, 2026, 6, 17,
+    ),
+  ];
+
+  it('matches only the menu that contains today', () => {
+    const match = findCurrentWeekMenu(candidates, julySix2026);
+
+    assert.ok(match);
+    assert.equal(match.href, 'https://example.com/july.pdf');
+    assert.equal(match.label, 'Campus Center Food Court Menu 06 July to 10 July');
+  });
+
+  it('returns null on weekends between published menu ranges', () => {
+    assert.equal(findCurrentWeekMenu(candidates, julyEleven2026), null);
+  });
+
+  it('does not fall back to the first or nearest menu', () => {
+    const onlyPastAndFuture = [candidates[0], candidates[2]];
+    assert.equal(findCurrentWeekMenu(onlyPastAndFuture, julySix2026), null);
+  });
+});
+
+describe('isTodayWithinRange', () => {
+  it('treats range endpoints as inclusive', () => {
+    const start = new Date(2026, 6, 6);
+    const end = new Date(2026, 6, 10);
+
+    assert.equal(isTodayWithinRange(julySix2026, start, end), true);
+    assert.equal(isTodayWithinRange({ year: 2026, month: 6, day: 10 }, start, end), true);
+    assert.equal(isTodayWithinRange(julyEleven2026, start, end), false);
+  });
+});
+
+describe('collectCandidatesFromEmbeddedJson', () => {
+  it('extracts menu labels and PDF URIs from embedded page JSON', () => {
+    const html = `
+      "name":"Campus Center Food Court Menu 06 July to 10 July","link":{"media":{"content":{"main":{"uri":"/web/en-us/media/26-0706%20menu_tcm17-89982.pdf"}}}}
+      "name":"Campus Center Food Court Menu 13 July to 17 July","link":{"media":{"content":{"main":{"uri":"/web/en-us/media/26-0713%20menu_tcm17-90068.pdf"}}}}
+    `;
+
+    const candidates = collectCandidatesFromEmbeddedJson(html, julySix2026);
+
+    assert.equal(candidates.length, 2);
+    assert.equal(candidates[0].label, 'Campus Center Food Court Menu 06 July to 10 July');
+    assert.equal(
+      candidates[0].href,
+      'https://media-prd.sodexomyway.net/web/en-us/media/26-0706%20menu_tcm17-89982.pdf',
+    );
+  });
+});
+
+describe('collectCandidatesFromDom', () => {
+  it('reads menu links from MenuLinkContainer anchors', () => {
+    const html = `
+      <div class="Locationstyles__MenuLinkContainer-sc-nt7jmt-17">
+        <a href="https://media-prd.sodexomyway.net/web/en-us/media/week-one.pdf">
+          Campus Center Food Court Menu 06 July to 10 July
+        </a>
+      </div>
+      <div class="Locationstyles__MenuLinkContainer-sc-nt7jmt-17">
+        <a href="https://media-prd.sodexomyway.net/web/en-us/media/week-two.pdf">
+          Campus Center Food Court Menu 13 July to 17 July
+        </a>
+      </div>
+    `;
+
+    const doc = new JSDOM(html).window.document;
+    const candidates = collectCandidatesFromDom(doc, julySix2026);
+
+    assert.equal(candidates.length, 2);
+    assert.equal(candidates[0].label, 'Campus Center Food Court Menu 06 July to 10 July');
+    assert.equal(candidates[1].label, 'Campus Center Food Court Menu 13 July to 17 July');
+  });
+});
+
+describe('mergeMenuCandidates', () => {
+  it('deduplicates candidates by normalized PDF href', () => {
+    const domCandidates = [
+      createMenuCandidate(
+        'Campus Center Food Court Menu 06 July to 10 July',
+        'https://media-prd.sodexomyway.net/web/en-us/media/menu.pdf',
+        julySix2026,
+      ),
+    ].filter((candidate): candidate is MenuCandidate => candidate !== null);
+
+    const jsonCandidates = [
+      createMenuCandidate(
+        'Campus Center Food Court Menu 06 July to 10 July',
+        '/web/en-us/media/menu.pdf',
+        julySix2026,
+      ),
+    ].filter((candidate): candidate is MenuCandidate => candidate !== null);
+
+    const merged = mergeMenuCandidates(domCandidates, jsonCandidates);
+
+    assert.equal(merged.length, 1);
+    assert.equal(
+      merged[0].href,
+      'https://media-prd.sodexomyway.net/web/en-us/media/menu.pdf',
+    );
+  });
+});
+
+describe('createMenuCandidate', () => {
+  it('builds a normalized candidate from a label and href', () => {
+    const candidate = createMenuCandidate(
+      'Campus Center Food Court Menu July 6 to July 10',
+      '/web/en-us/media/menu.pdf',
+      julySix2026,
+    );
+
+    assert.ok(candidate);
+    assert.equal(candidate.href, 'https://media-prd.sodexomyway.net/web/en-us/media/menu.pdf');
+    assertDate(candidate.startDate, 2026, 6, 6);
+    assertDate(candidate.endDate, 2026, 6, 10);
+  });
+
+  it('returns null when the label does not include a parseable date range', () => {
+    assert.equal(
+      createMenuCandidate('Campus Center Food Court Menu', '/web/en-us/media/menu.pdf', julySix2026),
+      null,
+    );
+    assert.equal(
+      createMenuCandidate(
+        'Campus Center Food Court Menu Mon 6 Jul - Fri 10 Jul',
+        '/web/en-us/media/menu.pdf',
+        julySix2026,
+      ),
+      null,
+    );
+  });
+});

--- a/src/lib/ccMenuParsing.ts
+++ b/src/lib/ccMenuParsing.ts
@@ -1,0 +1,354 @@
+export const PDF_MEDIA_BASE = 'https://media-prd.sodexomyway.net';
+export const HST_TIMEZONE = 'Pacific/Honolulu';
+
+const MONTH_MAP: Record<string, number> = {};
+[
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+].forEach((month, index) => {
+  MONTH_MAP[month.toLowerCase()] = index;
+  MONTH_MAP[month.slice(0, 3).toLowerCase()] = index;
+});
+
+// Primary: "06 July to 10 July", "29 June - 03 July", "6th July to 10th July"
+const DAY_MONTH_RANGE_REGEX = /(\d{1,2})(?:st|nd|rd|th)?\s+([A-Za-z]+\.?)\s+(?:to|–|—|-)\s+(\d{1,2})(?:st|nd|rd|th)?\s+([A-Za-z]+\.?)/i;
+
+// Secondary: "July 6 to July 10", "Jul 6 - Jul 10"
+const MONTH_DAY_RANGE_REGEX = /([A-Za-z]+\.?)\s+(\d{1,2})(?:st|nd|rd|th)?\s+(?:to|–|—|-)\s+([A-Za-z]+\.?)\s+(\d{1,2})(?:st|nd|rd|th)?/i;
+
+// Secondary: "7/6 to 7/10", "07/06/2026 to 07/10/2026"
+const NUMERIC_RANGE_REGEX = /(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?\s+(?:to|–|—|-)\s+(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?/;
+
+// Secondary: "2026-07-06 to 2026-07-10"
+const ISO_RANGE_REGEX = /(\d{4})-(\d{1,2})-(\d{1,2})\s+(?:to|–|—|-)\s+(\d{4})-(\d{1,2})-(\d{1,2})/;
+
+const MENU_LABEL_REGEX = /Campus Center Food Court Menu/i;
+const EMBEDDED_MENU_BLOCK_REGEX = /"name":"(Campus Center Food Court Menu [^"]+)"[\s\S]*?"uri":"(\/web\/en-us\/media\/[^"]+\.pdf)"/g;
+
+export interface DateParts {
+  year: number;
+  month: number;
+  day: number;
+}
+
+export interface MenuCandidate {
+  href: string;
+  label: string;
+  startDate: Date;
+  endDate: Date;
+}
+
+export interface ParsedMenuDateRange {
+  startDate: Date;
+  endDate: Date;
+  format: string;
+}
+
+export function getTodayInHST(now = new Date()): DateParts {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: HST_TIMEZONE,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  });
+
+  const parts = formatter.formatToParts(now);
+  return {
+    year: Number(parts.find((part) => part.type === 'year')?.value),
+    month: Number(parts.find((part) => part.type === 'month')?.value) - 1,
+    day: Number(parts.find((part) => part.type === 'day')?.value),
+  };
+}
+
+export function formatDateParts(parts: DateParts): string {
+  const month = String(parts.month + 1).padStart(2, '0');
+  const day = String(parts.day).padStart(2, '0');
+  return `${parts.year}-${month}-${day}`;
+}
+
+function parseMonth(monthText: string): number | undefined {
+  const normalized = monthText.toLowerCase().replace(/\./g, '');
+  return MONTH_MAP[normalized];
+}
+
+function parseOptionalYear(yearText: string | undefined, today: DateParts): number {
+  if (!yearText) {
+    return today.year;
+  }
+
+  const year = parseInt(yearText, 10);
+  if (yearText.length === 2) {
+    return 2000 + year;
+  }
+
+  return year;
+}
+
+function buildDateRangeWithYears(
+  startDay: number,
+  startMonth: number,
+  startYear: number,
+  endDay: number,
+  endMonth: number,
+  endYear: number,
+): { startDate: Date; endDate: Date } {
+  return {
+    startDate: new Date(startYear, startMonth, startDay),
+    endDate: new Date(endYear, endMonth, endDay),
+  };
+}
+
+function buildDateRange(
+  startDay: number,
+  startMonth: number,
+  endDay: number,
+  endMonth: number,
+  today: DateParts,
+): { startDate: Date; endDate: Date } {
+  const startDate = new Date(today.year, startMonth, startDay);
+  const endDate = new Date(today.year, endMonth, endDay);
+
+  if (endDate < startDate) {
+    if (today.month <= endMonth) {
+      startDate.setFullYear(startDate.getFullYear() - 1);
+    } else {
+      endDate.setFullYear(endDate.getFullYear() + 1);
+    }
+  }
+
+  return { startDate, endDate };
+}
+
+export function isTodayWithinRange(today: DateParts, startDate: Date, endDate: Date): boolean {
+  const todayValue = Date.UTC(today.year, today.month, today.day);
+  const startValue = Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  const endValue = Date.UTC(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
+  return todayValue >= startValue && todayValue <= endValue;
+}
+
+export function normalizePdfHref(href: string): string {
+  if (href.startsWith('http://') || href.startsWith('https://')) {
+    return href;
+  }
+  if (href.startsWith('/')) {
+    return `${PDF_MEDIA_BASE}${href}`;
+  }
+  return href;
+}
+
+function parseDayMonthRange(label: string, today: DateParts): { startDate: Date; endDate: Date } | null {
+  const match = label.match(DAY_MONTH_RANGE_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const startDay = parseInt(match[1], 10);
+  const startMonth = parseMonth(match[2]);
+  const endDay = parseInt(match[3], 10);
+  const endMonth = parseMonth(match[4]);
+
+  if (startMonth === undefined || endMonth === undefined) {
+    return null;
+  }
+
+  return buildDateRange(startDay, startMonth, endDay, endMonth, today);
+}
+
+function parseMonthDayRange(label: string, today: DateParts): { startDate: Date; endDate: Date } | null {
+  const match = label.match(MONTH_DAY_RANGE_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const startMonth = parseMonth(match[1]);
+  const startDay = parseInt(match[2], 10);
+  const endMonth = parseMonth(match[3]);
+  const endDay = parseInt(match[4], 10);
+
+  if (startMonth === undefined || endMonth === undefined) {
+    return null;
+  }
+
+  return buildDateRange(startDay, startMonth, endDay, endMonth, today);
+}
+
+function parseNumericRange(label: string, today: DateParts): { startDate: Date; endDate: Date } | null {
+  const match = label.match(NUMERIC_RANGE_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const startMonth = parseInt(match[1], 10) - 1;
+  const startDay = parseInt(match[2], 10);
+  const startYear = parseOptionalYear(match[3], today);
+  const endMonth = parseInt(match[4], 10) - 1;
+  const endDay = parseInt(match[5], 10);
+  const endYear = parseOptionalYear(match[6], today);
+
+  if (
+    startMonth < 0 || startMonth > 11
+    || endMonth < 0 || endMonth > 11
+    || startDay < 1 || startDay > 31
+    || endDay < 1 || endDay > 31
+  ) {
+    return null;
+  }
+
+  if (!match[3] && !match[6]) {
+    return buildDateRange(startDay, startMonth, endDay, endMonth, today);
+  }
+
+  return buildDateRangeWithYears(startDay, startMonth, startYear, endDay, endMonth, endYear);
+}
+
+function parseIsoRange(label: string): { startDate: Date; endDate: Date } | null {
+  const match = label.match(ISO_RANGE_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const startYear = parseInt(match[1], 10);
+  const startMonth = parseInt(match[2], 10) - 1;
+  const startDay = parseInt(match[3], 10);
+  const endYear = parseInt(match[4], 10);
+  const endMonth = parseInt(match[5], 10) - 1;
+  const endDay = parseInt(match[6], 10);
+
+  return buildDateRangeWithYears(startDay, startMonth, startYear, endDay, endMonth, endYear);
+}
+
+export function parseMenuDateRange(label: string, today: DateParts): ParsedMenuDateRange | null {
+  const parsers: Array<{
+    format: string;
+    parse: (text: string, referenceToday: DateParts) => { startDate: Date; endDate: Date } | null;
+  }> = [
+    { format: 'day-month', parse: parseDayMonthRange },
+    { format: 'month-day', parse: parseMonthDayRange },
+    { format: 'numeric', parse: parseNumericRange },
+    {
+      format: 'iso',
+      parse: (text) => parseIsoRange(text),
+    },
+  ];
+
+  for (const parser of parsers) {
+    const result = parser.parse(label, today);
+    if (!result) {
+      continue;
+    }
+
+    return { ...result, format: parser.format };
+  }
+
+  return null;
+}
+
+export function createMenuCandidate(
+  label: string,
+  href: string,
+  today: DateParts,
+): MenuCandidate | null {
+  if (!MENU_LABEL_REGEX.test(label)) {
+    return null;
+  }
+
+  const dateRange = parseMenuDateRange(label, today);
+  if (!dateRange) {
+    return null;
+  }
+
+  return {
+    href: normalizePdfHref(href),
+    label,
+    startDate: dateRange.startDate,
+    endDate: dateRange.endDate,
+  };
+}
+
+function addCandidate(
+  candidates: MenuCandidate[],
+  seenHrefs: Set<string>,
+  label: string,
+  href: string,
+  today: DateParts,
+): void {
+  const candidate = createMenuCandidate(label, href, today);
+  if (!candidate || seenHrefs.has(candidate.href)) {
+    return;
+  }
+
+  seenHrefs.add(candidate.href);
+  candidates.push(candidate);
+}
+
+export function collectCandidatesFromDom(doc: Document, today: DateParts): MenuCandidate[] {
+  const candidates: MenuCandidate[] = [];
+  const seenHrefs = new Set<string>();
+
+  const menuContainers = doc.querySelectorAll('div[class*="MenuLinkContainer"]');
+  menuContainers.forEach((container) => {
+    const anchor = container.querySelector('a') as HTMLAnchorElement | null;
+    if (!anchor?.href) {
+      return;
+    }
+
+    const label = (anchor.textContent || '').trim();
+    addCandidate(candidates, seenHrefs, label, anchor.href, today);
+  });
+
+  if (candidates.length === 0) {
+    doc.querySelectorAll('a[href*=".pdf"]').forEach((anchor) => {
+      const link = anchor as HTMLAnchorElement;
+      const label = (link.textContent || '').trim();
+      if (!label.includes('Food Court Menu')) {
+        return;
+      }
+      addCandidate(candidates, seenHrefs, label, link.href, today);
+    });
+  }
+
+  return candidates;
+}
+
+export function collectCandidatesFromEmbeddedJson(html: string, today: DateParts): MenuCandidate[] {
+  const candidates: MenuCandidate[] = [];
+  const seenHrefs = new Set<string>();
+
+  for (const match of html.matchAll(EMBEDDED_MENU_BLOCK_REGEX)) {
+    addCandidate(candidates, seenHrefs, match[1], match[2], today);
+  }
+
+  return candidates;
+}
+
+export function mergeMenuCandidates(...groups: MenuCandidate[][]): MenuCandidate[] {
+  const seenHrefs = new Set<string>();
+  const merged: MenuCandidate[] = [];
+
+  groups.flat().forEach((candidate) => {
+    if (seenHrefs.has(candidate.href)) {
+      return;
+    }
+    seenHrefs.add(candidate.href);
+    merged.push(candidate);
+  });
+
+  return merged;
+}
+
+export function findCurrentWeekMenu(candidates: MenuCandidate[], today: DateParts): MenuCandidate | null {
+  const currentWeekMenus = candidates.filter((candidate) =>
+    isTodayWithinRange(today, candidate.startDate, candidate.endDate));
+
+  if (currentWeekMenus.length === 0) {
+    return null;
+  }
+
+  if (currentWeekMenus.length > 1) {
+    currentWeekMenus.sort(
+      (left, right) => left.startDate.getTime() - right.startDate.getTime(),
+    );
+  }
+
+  return currentWeekMenus[0];
+}

--- a/src/lib/menuActions.ts
+++ b/src/lib/menuActions.ts
@@ -44,23 +44,20 @@ async function getCheckCCMenu(language: string): Promise<DayMenu[]> {
       // No cached menu, scrape and parse the PDF
       const menuURL = 'https://uhm.sodexomyway.com/en-us/locations/campus-center-food-court';
       console.log(`No cached English menu. Scraping PDF URL from: ${menuURL}`);
-      let menuPdf: string | null = null;
 
-      try {
-        menuPdf = await scrapeCCUrl(menuURL);
-        console.log(`Scraped PDF URL: ${menuPdf}`);
-      } catch (scrapeError) {
-        console.warn(`Failed to scrape PDF URL: ${scrapeError}`);
-        const staticPdf = '/cc-menus/menu.pdf';
-        menuPdf = `${process.env.NEXTAUTH_URL || 'http://localhost:3000'}${staticPdf}`;
-        console.log(`Falling back to static PDF: ${menuPdf}`);
+      const menuPdf = await scrapeCCUrl(menuURL);
+      if (!menuPdf) {
+        console.warn(`No Campus Center menu PDF found for the current week (${currentWeekOf})`);
+        return [];
       }
 
+      console.log(`Scraped PDF URL: ${menuPdf}`);
       console.log(`Parsing PDF for week ${currentWeekOf}`);
       englishMenuFromDb = await parseCCMenuFromPDF(menuPdf);
 
       if (!englishMenuFromDb.weekOne || englishMenuFromDb.weekOne.length === 0) {
-        throw new Error(`English menu is missing after PDF parse for ${currentWeekOf}.`);
+        console.warn(`English menu is missing after PDF parse for ${currentWeekOf}`);
+        return [];
       }
     }
 

--- a/src/lib/scrapeCCUrl.ts
+++ b/src/lib/scrapeCCUrl.ts
@@ -2,7 +2,17 @@
 import { JSDOM, VirtualConsole } from 'jsdom';
 import fetch from 'node-fetch';
 
-export default async function scrapeCCUrl(url: string): Promise<string> {
+import {
+  collectCandidatesFromDom,
+  collectCandidatesFromEmbeddedJson,
+  findCurrentWeekMenu,
+  formatDateParts,
+  getTodayInHST,
+  isTodayWithinRange,
+  mergeMenuCandidates,
+} from '@/lib/ccMenuParsing';
+
+export default async function scrapeCCUrl(url: string): Promise<string | null> {
   console.log(`Starting scrapeCCUrl for: ${url}`);
   if (typeof window !== 'undefined') {
     throw new Error('scrapeCCUrl can only be run in a Node.js environment');
@@ -23,7 +33,6 @@ export default async function scrapeCCUrl(url: string): Promise<string> {
     throw new Error(`Failed to fetch the URL: ${response.statusText}`);
   }
 
-  console.log(`Successfully fetched URL, content length: ${response.headers.get('content-length')}`);
   const html = await response.text();
   console.log(`HTML length: ${html.length} characters`);
 
@@ -36,127 +45,40 @@ export default async function scrapeCCUrl(url: string): Promise<string> {
     }
   });
 
-  console.log('Parsing HTML with JSDOM...');
-  const dom = new JSDOM(html, {
-    virtualConsole,
+  const dom = new JSDOM(html, { virtualConsole });
+  const doc = dom.window.document;
+  const today = getTodayInHST();
+  const todayLabel = formatDateParts(today);
+  console.log(
+    `[scrapeCCUrl] Current week (HST): ${todayLabel} (${new Date(today.year, today.month, today.day).toDateString()})`,
+  );
+
+  const candidates = mergeMenuCandidates(
+    collectCandidatesFromDom(doc, today),
+    collectCandidatesFromEmbeddedJson(html, today),
+  );
+
+  console.log(`Found ${candidates.length} menu candidate(s) on page`);
+  candidates.forEach((candidate, index) => {
+    const matchesCurrentWeek = isTodayWithinRange(today, candidate.startDate, candidate.endDate);
+    console.log(
+      `Candidate ${index}: "${candidate.label}" (${candidate.startDate.toDateString()} – ${candidate.endDate.toDateString()}) | current week match: ${matchesCurrentWeek ? 'YES' : 'no'}`,
+    );
   });
 
-  const doc = dom.window.document;
-  console.log('Looking for menu link container divs...');
-  const divs = doc.querySelectorAll('div[class*="MenuLinkContainer"]');
-  if (divs.length === 0) {
-    console.error('Menu link container div not found');
-    console.log('Available divs with similar classes:');
-    const allDivs = doc.querySelectorAll('div');
-    allDivs.forEach((d, index) => {
-      if (d.className && d.className.includes('Menu')) {
-        console.log(`Div ${index}: ${d.className}`);
-      }
-    });
-    throw new Error('Menu link container div not found');
+  const currentMenu = findCurrentWeekMenu(candidates, today);
+  if (!currentMenu) {
+    console.warn(
+      `[scrapeCCUrl] No menu matched the current week in HST (${todayLabel})`,
+    );
+    return null;
   }
 
-  console.log(`Found ${divs.length} menu link container div(s)`);
-
-  // Month abbreviation map for parsing anchor text dates
-  const monthMap: Record<string, number> = {
-    Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5,
-    Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11,
-  };
-
-  const now = new Date();
-
-  interface Candidate { anchor: HTMLAnchorElement; startDate: Date; endDate: Date; }
-  const candidates: Candidate[] = [];
-  let firstAnchorOnPage: HTMLAnchorElement | null = null;
-  let firstAnchorHasDate = false;
-  const dateRangeRegex = /(\d{1,2})\s+([A-Za-z]{3})\s+to\s+(\d{1,2})\s+([A-Za-z]{3})/;
-
-  // Iterate over all matching divs and collect parsed date ranges
-  for (let i = 0; i < divs.length; i++) {
-    const anchor = divs[i].querySelector('a') as HTMLAnchorElement | null;
-    if (!anchor) continue;
-
-    if (!firstAnchorOnPage) {
-      firstAnchorOnPage = anchor;
-    }
-
-    const text = anchor.textContent || '';
-    console.log(`Div ${i} anchor text: "${text}"`);
-
-    // Expected format: "... Menu DD Mon to DD Mon"
-    const dateMatch = text.match(dateRangeRegex);
-    if (!dateMatch) {
-      console.log(`Div ${i}: could not parse date range from anchor text`);
-      continue;
-    }
-
-    if (anchor === firstAnchorOnPage) {
-      firstAnchorHasDate = true;
-    }
-
-    const startDay = parseInt(dateMatch[1], 10);
-    const startMonth = monthMap[dateMatch[2]];
-    const endDay = parseInt(dateMatch[3], 10);
-    const endMonth = monthMap[dateMatch[4]];
-
-    if (startMonth === undefined || endMonth === undefined) {
-      console.log(`Div ${i}: unrecognised month abbreviation`);
-      continue;
-    }
-
-    // Build full Date objects; infer the year from the current date
-    const startDate = new Date(now.getFullYear(), startMonth, startDay);
-    const endDate = new Date(now.getFullYear(), endMonth, endDay, 23, 59, 59);
-
-    // Handle year boundary (e.g. range spans Dec-Jan)
-    if (endDate < startDate) {
-      if (now.getMonth() <= endMonth) {
-        startDate.setFullYear(startDate.getFullYear() - 1);
-      } else {
-        endDate.setFullYear(endDate.getFullYear() + 1);
-      }
-    }
-
-    console.log(`Div ${i}: date range ${startDate.toDateString()} – ${endDate.toDateString()}`);
-
-    if (now >= startDate && now <= endDate) {
-      console.log(`Div ${i} matches the current week. Returning href: ${anchor.href}`);
-      return anchor.href;
-    }
-
-    candidates.push({ anchor, startDate, endDate });
-  }
-
-  if (firstAnchorOnPage && !firstAnchorHasDate) {
-    console.warn('First menu button does not include a date range; returning first menu link on page');
-    return firstAnchorOnPage.href;
-  }
-
-  // Fallback: pick the next upcoming range (closest startDate after today),
-  // or if everything is in the past, the most recently ended range.
-  console.warn('No anchor matched the current week; selecting nearest date range as fallback');
-
-  const upcoming = candidates
-    .filter(c => c.startDate > now)
-    .sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
-
-  if (upcoming.length > 0) {
-    console.log(`Fallback: next upcoming range starts ${upcoming[0].startDate.toDateString()}. Returning href: ${upcoming[0].anchor.href}`);
-    return upcoming[0].anchor.href;
-  }
-
-  const past = candidates
-    .filter(c => c.endDate < now)
-    .sort((a, b) => b.endDate.getTime() - a.endDate.getTime());
-
-  if (past.length > 0) {
-    console.log(`Fallback: most recent past range ended ${past[0].endDate.toDateString()}. Returning href: ${past[0].anchor.href}`);
-    return past[0].anchor.href;
-  }
-
-  console.error('No anchor elements found in any menu link container');
-  throw new Error('Anchor element not found');
+  console.log(
+    `[scrapeCCUrl] Matched current week ${todayLabel} to "${currentMenu.label}" (${currentMenu.startDate.toDateString()} – ${currentMenu.endDate.toDateString()})`,
+  );
+  console.log(`Current week menu found. Returning href: ${currentMenu.href}`);
+  return currentMenu.href;
 }
 
 export async function scrapeCCHours(url: string): Promise<string | null> {
@@ -193,10 +115,9 @@ export async function scrapeCCHours(url: string): Promise<string | null> {
   const doc = dom.window.document;
 
   console.log('[scrapeCCHours] Looking for OpenChip status wrapper...');
-  // Find all divs and look for one with a class that starts with "OpenChipstyles__Wrapper"
   const allDivs = doc.querySelectorAll('div[class]');
   let statusWrapper = null;
-  
+
   for (let i = 0; i < allDivs.length; i++) {
     const div = allDivs[i];
     if (div.className && div.className.includes('OpenChipstyles__Wrapper')) {
@@ -212,21 +133,18 @@ export async function scrapeCCHours(url: string): Promise<string | null> {
 
   console.log(`[scrapeCCHours] Found status wrapper. innerHTML preview: "${statusWrapper.innerHTML.slice(0, 200)}"`);
 
-  // Look for the container div with aria-label
   const containerDiv = statusWrapper.querySelector('div.container[aria-label]');
   if (!containerDiv) {
     console.warn('[scrapeCCHours] div.container with aria-label not found inside status wrapper');
     return null;
   }
 
-  // Extract status from aria-label attribute
   const status = containerDiv.getAttribute('aria-label');
   if (!status) {
     console.warn('[scrapeCCHours] aria-label attribute not found');
     return null;
   }
 
-  // Capitalize first letter
   const result = status.charAt(0).toUpperCase() + status.slice(1);
   console.log(`[scrapeCCHours] Extracted status: "${result}"`);
   return result;


### PR DESCRIPTION
Add tsx test runner with Node.js native test framework and extract menu date parsing logic into a reusable ccMenuParsing library. Refactor scrapeCCUrl to use the new parsing functions. Update error handling in menuActions to gracefully return empty results instead of throwing errors when menus are unavailable. Add comprehensive unit tests for parsing logic covering multiple date formats and edge cases.