### PR TITLE
Refactor manualTranslate; update parsing & prompts

### DIFF
--- a/src/app/utils/api/openai.ts
+++ b/src/app/utils/api/openai.ts
@@ -341,7 +341,7 @@ async function fetchOpenAI(
   }
 
   // --- No cached menu found, call OpenAI ---
-  const maxTokens = 8000;
+  const maxTokens = 10000;
   const jsonSchema = (option === Location.CAMPUS_CENTER) ? ccJsonSchema : sdxJsonSchema;
 
   const response = await client.responses.create({

--- a/src/lib/ccMenuParsing.test.ts
+++ b/src/lib/ccMenuParsing.test.ts
@@ -217,8 +217,10 @@ describe('isTodayWithinRange', () => {
 describe('collectCandidatesFromEmbeddedJson', () => {
   it('extracts menu labels and PDF URIs from embedded page JSON', () => {
     const html = `
-      "name":"Campus Center Food Court Menu 06 July to 10 July","link":{"media":{"content":{"main":{"uri":"/web/en-us/media/26-0706%20menu_tcm17-89982.pdf"}}}}
-      "name":"Campus Center Food Court Menu 13 July to 17 July","link":{"media":{"content":{"main":{"uri":"/web/en-us/media/26-0713%20menu_tcm17-90068.pdf"}}}}
+      "name":"Campus Center Food Court Menu 06 July to 10 July",
+      "link":{"media":{"content":{"main":{"uri":"/web/en-us/media/26-0706%20menu_tcm17-89982.pdf"}}}}
+      "name":"Campus Center Food Court Menu 13 July to 17 July",
+      "link":{"media":{"content":{"main":{"uri":"/web/en-us/media/26-0713%20menu_tcm17-90068.pdf"}}}}
     `;
 
     const candidates = collectCandidatesFromEmbeddedJson(html, julySix2026);

--- a/src/lib/ccMenuParsing.ts
+++ b/src/lib/ccMenuParsing.ts
@@ -11,19 +11,34 @@ const MONTH_MAP: Record<string, number> = {};
 });
 
 // Primary: "06 July to 10 July", "29 June - 03 July", "6th July to 10th July"
-const DAY_MONTH_RANGE_REGEX = /(\d{1,2})(?:st|nd|rd|th)?\s+([A-Za-z]+\.?)\s+(?:to|–|—|-)\s+(\d{1,2})(?:st|nd|rd|th)?\s+([A-Za-z]+\.?)/i;
+const DAY_MONTH_RANGE_REGEX = new RegExp(
+  '(\\d{1,2})(?:st|nd|rd|th)?\\s+([A-Za-z]+\\.?)\\s+(?:to|–|—|-)\\s+'
+  + '(\\d{1,2})(?:st|nd|rd|th)?\\s+([A-Za-z]+\\.?)',
+  'i',
+);
 
 // Secondary: "July 6 to July 10", "Jul 6 - Jul 10"
-const MONTH_DAY_RANGE_REGEX = /([A-Za-z]+\.?)\s+(\d{1,2})(?:st|nd|rd|th)?\s+(?:to|–|—|-)\s+([A-Za-z]+\.?)\s+(\d{1,2})(?:st|nd|rd|th)?/i;
+const MONTH_DAY_RANGE_REGEX = new RegExp(
+  '([A-Za-z]+\\.?)\\s+(\\d{1,2})(?:st|nd|rd|th)?\\s+(?:to|–|—|-)\\s+'
+  + '([A-Za-z]+\\.?)\\s+(\\d{1,2})(?:st|nd|rd|th)?',
+  'i',
+);
 
 // Secondary: "7/6 to 7/10", "07/06/2026 to 07/10/2026"
-const NUMERIC_RANGE_REGEX = /(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?\s+(?:to|–|—|-)\s+(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?/;
+const NUMERIC_RANGE_REGEX = new RegExp(
+  '(\\d{1,2})\\/(\\d{1,2})(?:\\/(\\d{2,4}))?\\s+(?:to|–|—|-)\\s+'
+  + '(\\d{1,2})\\/(\\d{1,2})(?:\\/(\\d{2,4}))?',
+);
 
 // Secondary: "2026-07-06 to 2026-07-10"
 const ISO_RANGE_REGEX = /(\d{4})-(\d{1,2})-(\d{1,2})\s+(?:to|–|—|-)\s+(\d{4})-(\d{1,2})-(\d{1,2})/;
 
 const MENU_LABEL_REGEX = /Campus Center Food Court Menu/i;
-const EMBEDDED_MENU_BLOCK_REGEX = /"name":"(Campus Center Food Court Menu [^"]+)"[\s\S]*?"uri":"(\/web\/en-us\/media\/[^"]+\.pdf)"/g;
+const EMBEDDED_MENU_BLOCK_REGEX = new RegExp(
+  '"name":"(Campus Center Food Court Menu [^"]+)"[\\s\\S]*?'
+  + '"uri":"(\\/web\\/en-us\\/media\\/[^"]+\\.pdf)"',
+  'g',
+);
 
 export interface DateParts {
   year: number;

--- a/src/lib/manualTranslate.test.ts
+++ b/src/lib/manualTranslate.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import jpManualReplace from './manualTranslate';
+import type { DayMenu, MenuResponse } from '../types/menuTypes';
+
+const makeDayMenu = (plateLunch: string[], grabAndGo: string[]): DayMenu => ({
+  name: 'Monday',
+  plateLunch,
+  grabAndGo,
+  specialMessage: 'Closed for holiday',
+});
+
+const makeMenu = (weekOne: DayMenu[], weekTwo: DayMenu[] = []): MenuResponse => ({
+  weekOne,
+  weekTwo,
+});
+
+describe('jpManualReplace', () => {
+  it('replaces dish-specific translations', () => {
+    const result = jpManualReplace(makeMenu([
+      makeDayMenu(
+        [
+          'チキンブルスケッタサラダ（ブルスケッタ風味のチキンサラダ）',
+          'ブラックビーンシュリンプ（黒豆入りえび炒め）と焼きそば',
+          'スイート＆サワーフィッシュ（甘酢味の白身魚）とチャーハン',
+        ],
+        ['チキンシーザー ベーコンラップ'],
+      ),
+    ]));
+
+    assert.equal(
+      result.weekOne[0].plateLunch[0],
+      'チキンブルスケッタサラダ（トマトを使ったブルスケッタ風チキンサラダ）',
+    );
+    assert.equal(
+      result.weekOne[0].plateLunch[1],
+      'ブラックビーンシュリンプ（黒豆ソースの中華風えび炒め）',
+    );
+    assert.equal(result.weekOne[0].plateLunch[2], '甘酢白身魚とチャーハン');
+    assert.equal(result.weekOne[0].grabAndGo[0], 'チキンシーザー＆ベーコンラップ');
+  });
+
+  it('applies shared substring replacements to plate lunch and grab-and-go', () => {
+    const result = jpManualReplace(makeMenu([
+      makeDayMenu(
+        ['バリューボウル with chicken', 'ミニまたは丼', 'Turkey with グレービー'],
+        ['テイタートッツ side', 'ロード fries', 'ミックスプレート', 'Turkeyクラブ'],
+      ),
+    ]));
+
+    assert.equal(result.weekOne[0].plateLunch[0], 'お得サイズボウル with chicken');
+    assert.equal(result.weekOne[0].plateLunch[1], 'ミニまたはボウル');
+    assert.equal(result.weekOne[0].plateLunch[2], 'Turkey with グレイビーソース');
+    assert.equal(result.weekOne[0].grabAndGo[0], 'ポテトフライド side');
+    assert.equal(result.weekOne[0].grabAndGo[1], 'トッピング盛りだくさん fries');
+    assert.equal(result.weekOne[0].grabAndGo[2], '２種類プレート');
+    assert.equal(result.weekOne[0].grabAndGo[3], 'Turkeyクラブサンドイッチ');
+  });
+
+  it('does not let the generic blackened rule override dish-specific black bean shrimp', () => {
+    const result = jpManualReplace(makeMenu([
+      makeDayMenu(
+        ['ブラックビーンシュリンプ（黒豆入りえび炒め）と焼きそば'],
+        [],
+      ),
+    ]));
+
+    assert.equal(
+      result.weekOne[0].plateLunch[0],
+      'ブラックビーンシュリンプ（黒豆ソースの中華風えび炒め）',
+    );
+    assert.doesNotMatch(result.weekOne[0].plateLunch[0], /味付鶏肉/);
+  });
+
+  it('applies the blackened rule to other items containing ブラック', () => {
+    const result = jpManualReplace(makeMenu([
+      makeDayMenu([], ['ブラックニングチキン']),
+    ]));
+
+    assert.equal(result.weekOne[0].grabAndGo[0], 'ブラック（味付鶏肉）ニングチキン');
+  });
+
+  it('sets Japanese day names and preserves special messages', () => {
+    const result = jpManualReplace(makeMenu([
+      makeDayMenu(['unchanged item'], []),
+      makeDayMenu(['also unchanged'], []),
+    ]));
+
+    assert.equal(result.weekOne[0].name, '月曜日');
+    assert.equal(result.weekOne[1].name, '火曜日');
+    assert.equal(result.weekOne[0].specialMessage, 'Closed for holiday');
+  });
+
+  it('processes week two when present and handles missing week two', () => {
+    const withWeekTwo = jpManualReplace(makeMenu(
+      [makeDayMenu(['ミニまたは丼'], [])],
+      [makeDayMenu(['バリューボウル'], [])],
+    ));
+    const withoutWeekTwo = jpManualReplace({
+      weekOne: [makeDayMenu(['unchanged'], [])],
+      weekTwo: undefined as unknown as DayMenu[],
+    });
+
+    assert.equal(withWeekTwo.weekTwo[0].name, '月曜日');
+    assert.equal(withWeekTwo.weekTwo[0].plateLunch[0], 'お得サイズボウル');
+    assert.equal(withoutWeekTwo.weekTwo.length, 0);
+  });
+
+  it('leaves unmatched items unchanged', () => {
+    const result = jpManualReplace(makeMenu([
+      makeDayMenu(['Regular plate lunch'], ['Regular grab and go']),
+    ]));
+
+    assert.equal(result.weekOne[0].plateLunch[0], 'Regular plate lunch');
+    assert.equal(result.weekOne[0].grabAndGo[0], 'Regular grab and go');
+  });
+});

--- a/src/lib/manualTranslate.test.ts
+++ b/src/lib/manualTranslate.test.ts
@@ -49,12 +49,12 @@ describe('jpManualReplace', () => {
       ),
     ]));
 
-    assert.equal(result.weekOne[0].plateLunch[0], 'お得サイズボウル with chicken');
+    assert.equal(result.weekOne[0].plateLunch[0], 'バリューボウル (ミニボウル) with chicken');
     assert.equal(result.weekOne[0].plateLunch[1], 'ミニまたはボウル');
-    assert.equal(result.weekOne[0].plateLunch[2], 'Turkey with グレイビーソース');
+    assert.equal(result.weekOne[0].plateLunch[2], 'Turkey with グレービー');
     assert.equal(result.weekOne[0].grabAndGo[0], 'ポテトフライド side');
     assert.equal(result.weekOne[0].grabAndGo[1], 'トッピング盛りだくさん fries');
-    assert.equal(result.weekOne[0].grabAndGo[2], '２種類プレート');
+    assert.equal(result.weekOne[0].grabAndGo[2], 'ミックスプレート (選べる2種盛りプレート)');
     assert.equal(result.weekOne[0].grabAndGo[3], 'Turkeyクラブサンドイッチ');
   });
 
@@ -73,12 +73,12 @@ describe('jpManualReplace', () => {
     assert.doesNotMatch(result.weekOne[0].plateLunch[0], /味付鶏肉/);
   });
 
-  it('applies the blackened rule to other items containing ブラック', () => {
+  it('leaves other items containing ブラック unchanged when no rule matches', () => {
     const result = jpManualReplace(makeMenu([
       makeDayMenu([], ['ブラックニングチキン']),
     ]));
 
-    assert.equal(result.weekOne[0].grabAndGo[0], 'ブラック（味付鶏肉）ニングチキン');
+    assert.equal(result.weekOne[0].grabAndGo[0], 'ブラックニングチキン');
   });
 
   it('sets Japanese day names and preserves special messages', () => {
@@ -103,7 +103,7 @@ describe('jpManualReplace', () => {
     });
 
     assert.equal(withWeekTwo.weekTwo[0].name, '月曜日');
-    assert.equal(withWeekTwo.weekTwo[0].plateLunch[0], 'お得サイズボウル');
+    assert.equal(withWeekTwo.weekTwo[0].plateLunch[0], 'バリューボウル (ミニボウル)');
     assert.equal(withoutWeekTwo.weekTwo.length, 0);
   });
 

--- a/src/lib/manualTranslate.ts
+++ b/src/lib/manualTranslate.ts
@@ -2,105 +2,61 @@ import { MenuResponse, DayMenu } from '@/types/menuTypes';
 
 const jpDaysOfWeek = ['月曜日', '火曜日', '水曜日', '木曜日', '金曜日'];
 
-const jpManualReplace = (original: MenuResponse): MenuResponse => {
-  const replacedMenu: MenuResponse = {
-    weekOne: [],
-    weekTwo: [],
-  };
-  original.weekOne.forEach((dayMenu, index) => {
-    const replacedDayMenu: DayMenu = {
-      name: jpDaysOfWeek[index],
-      plateLunch: dayMenu.plateLunch.map((item) => {
-        // Replace Value Bowl
-        if (item.includes('バリューボウル')) {
-          return item.replace('バリューボウル', 'お得サイズボウル');
-        }
-        if (item.includes('グレービー')) {
-          return item.replace('グレービー', 'グレイビーソース');
-        }
-        return item;
-      }),
-      grabAndGo: dayMenu.grabAndGo.map((item) => {
-        // Replace Value Bowl
-        if (item.includes('バリューボウル')) {
-          return item.replace('バリューボウル', 'お得サイズボウル');
-        }
-        // Add Sandwich to Club
-        if (item.endsWith('クラブ')) {
-          return `${item}サンドイッチ`;
-        }
-        // Replace Tater Tots with Fried Potato
-        if (item.includes('テイタートッツ') || item.includes('テイタートット') || item.includes('テイタートツ')
-        || item.includes('タタートッツ')) {
-          return item.replace(/テイタートッツ|テイタートット|テイタートツ|タタートッツ/g, 'ポテトフライド');
-        }
-        // Replace Loaded with Lots of Toppings
-        if (item.includes('ロード')) {
-          return item.replace('ロード', 'トッピング盛りだくさん');
-        }
-        // Replace Blackened with Seasoned
-        if (item.includes('ブラックニング') || item.includes('ブラックニン') || item.includes('ブラックニング')
-        || item.includes('ブラック')) {
-          return item.replace(/ブラック|ブラックニング|ブラックニン|ブラックニング/g, 'ブラック（味付鶏肉）');
-        }
-        // Replace Mixed Plate
-        if (item.includes('ミックスプレート') || item.includes('ミクスプレート')) {
-          return item.replace('ミックスプレート', '２種類プレート');
-        }
-        return item;
-      }),
-      specialMessage: dayMenu.specialMessage,
-    };
-    replacedMenu.weekOne.push(replacedDayMenu);
-  });
-  if (!original.weekTwo) {
-    return replacedMenu;
-  }
-  original.weekTwo.forEach((dayMenu, index) => {
-    const replacedDayMenu: DayMenu = {
-      name: jpDaysOfWeek[index],
-      plateLunch: dayMenu.plateLunch.map((item) => {
-        // Replace Value Bowl
-        if (item.includes('バリューボウル')) {
-          return item.replace('バリューボウル', 'お得サイズボウル');
-        }
-        return item;
-      }),
-      grabAndGo: dayMenu.grabAndGo.map((item) => {
-        // Replace Value Bowl
-        if (item.includes('バリューボウル')) {
-          return item.replace('バリューボウル', 'お得サイズボウル');
-        }
-        // Add Sandwich to Club
-        if (item.endsWith('クラブ')) {
-          return `${item}サンドイッチ`;
-        }
-        // Replace Tater Tots with Fried Potato
-        if (item.includes('テイタートッツ') || item.includes('テイタートット') || item.includes('テイタートツ')
-        || item.includes('タタートッツ')) {
-          return item.replace(/テイタートッツ|テイタートット|テイタートツ|タタートッツ/g, 'ポテトフライド');
-        }
-        // Replace Loaded with Lots of Toppings
-        if (item.includes('ロード')) {
-          return item.replace('ロード', 'トッピング盛りだくさん');
-        }
-        // Replace Blackened with Seasoned
-        if (item.includes('ブラックニング') || item.includes('ブラックニン') || item.includes('ブラックニング')
-        || item.includes('ブラック')) {
-          return item.replace(/ブラック|ブラックニング|ブラックニン|ブラックニング/g, 'ブラック（味付鶏肉）');
-        }
-        // Replace Mixed Plate
-        if (item.includes('ミックスプレート') || item.includes('ミクスプレート')) {
-          return item.replace('ミックスプレート', '２種類プレート');
-        }
-        return item;
-      }),
-      specialMessage: dayMenu.specialMessage,
-    };
-    replacedMenu.weekTwo.push(replacedDayMenu);
-  });
-
-  return replacedMenu;
+type SubstringReplacement = {
+  from: string | RegExp;
+  to: string;
 };
+
+/**
+ * A rule returns the replaced string, or `null` when it doesn't apply to the item.
+ * Rules are evaluated in order and the first one that applies wins (mutually exclusive),
+ * matching the original early-return behavior.
+ */
+type ReplaceRule = (item: string) => string | null;
+
+const toRules = (replacements: SubstringReplacement[]): ReplaceRule[] => replacements.map(
+  ({ from, to }) => (item) => {
+    const result = item.replace(from, to);
+    return result === item ? null : result;
+  },
+);
+
+const SHARED_REPLACEMENTS: SubstringReplacement[] = [
+  { from: 'チキンブルスケッタサラダ（ブルスケッタ風味のチキンサラダ）', to: 'チキンブルスケッタサラダ（トマトを使ったブルスケッタ風チキンサラダ）' },
+  { from: 'ブラックビーンシュリンプ（黒豆入りえび炒め）と焼きそば', to: 'ブラックビーンシュリンプ（黒豆ソースの中華風えび炒め）' },
+  { from: 'チキンシーザー ベーコンラップ', to: 'チキンシーザー＆ベーコンラップ' },
+  { from: 'スイート＆サワーフィッシュ（甘酢味の白身魚）とチャーハン', to: '甘酢白身魚とチャーハン' },
+  { from: 'バリューボウル', to: 'バリューボウル (ミニボウル)' },
+  { from: '丼', to: 'ボウル' },
+  { from: /(.*クラブ)$/, to: '$1サンドイッチ' },
+  { from: /テイタートッツ|テイタートット|テイタートツ|タタートッツ/g, to: 'ポテトフライド' },
+  { from: 'ロード', to: 'トッピング盛りだくさん' },
+  { from: 'ミックスプレート', to: 'ミックスプレート (選べる2種盛りプレート)' },
+];
+
+const rules = toRules(SHARED_REPLACEMENTS);
+
+const applyRules = (item: string): string => {
+  for (const rule of rules) {
+    const replaced = rule(item);
+    if (replaced !== null) {
+      console.log(`[manualTranslate] Changed: "${item}" -> "${replaced}"`);
+      return replaced;
+    }
+  }
+  return item;
+};
+
+const replaceDayMenu = (dayMenu: DayMenu, index: number): DayMenu => ({
+  name: jpDaysOfWeek[index],
+  plateLunch: dayMenu.plateLunch.map(applyRules),
+  grabAndGo: dayMenu.grabAndGo.map(applyRules),
+  specialMessage: dayMenu.specialMessage,
+});
+
+const jpManualReplace = (original: MenuResponse): MenuResponse => ({
+  weekOne: original.weekOne.map(replaceDayMenu),
+  weekTwo: (original.weekTwo ?? []).map(replaceDayMenu),
+});
 
 export default jpManualReplace;

--- a/src/lib/menuActions.ts
+++ b/src/lib/menuActions.ts
@@ -66,49 +66,93 @@ async function getCheckCCMenu(language: string): Promise<DayMenu[]> {
     }
 
     console.log(`No ${language} menu found for ${currentWeekOf}. Translating now.`);
-  const prompt = `You are translating a cafeteria menu into ${language}.
 
-OUTPUT RULES
-1) Preserve the original structure and ordering exactly. Do not add, remove,
-   merge, or invent groups or items.
-2) Translate every group name and every menu item name into natural
-   ${language}.
-   - Group names: do not translate word-for-word. Use a natural equivalent
-     category name in ${language}.
-3) Parentheses notes are OPTIONAL and must be NECESSARY.
-   - Only add a short explanation in parentheses when the dish would still be
-     unclear to an average native speaker of ${language} AFTER
-     translation.
-   - If the translated name already clearly tells what it is, DO NOT add
-     parentheses.
+    const prompt =
+      `You are translating a cafeteria menu into ${language} for exchange students `
+      + `who need to quickly understand what each dish is.
 
-WHEN TO ADD PARENTHESES
-A) The item is culturally specific OR uses an unfamiliar dish name OR a
-   brand/place name OR a cooking style that many people in
-   ${language} would not recognize, AND
-B) The translation alone does not reveal the main ingredients or what kind
-   of dish it is, AND
-C) A one-phrase clarification would reduce confusion.
-
-WHEN NOT TO ADD PARENTHESES
-- If the translated name already makes the dish obvious (wrap, salad, grilled
-  chicken, garlic chicken, steak, lobster tail, fish & chips, Caesar salad,
-  etc.)
-- If it is just a normal combination of common ingredients and cooking
-  methods.
-- If the item name contains the main ingredient and form (example: "Asian
-  chicken wrap", "Garlic chicken", "New York steak", "Lobster tail").
-
-STYLE FOR PARENTHESES (if needed)
-- Keep it to 6 to 12 words in ${language}.
-- Explain what it is using ingredients or dish type, not extra marketing.
-
-SPECIAL CASES
-- Keep proper nouns as-is (example: "Cajun", "Mesquite",
-  "Chimichurri", "Huli Huli") and optionally explain ONLY if
-  needed.
-
-Return ONLY the translated menu text.\n`;
+    TARGET READER
+    Assume the reader is a native speaker of ${language}, but may not be familiar with American,
+    Hawaiian, Filipino, local-style plate lunch, cafeteria, or regional restaurant dishes.
+    The goal is not only to translate the name, but to help the student quickly imagine the main food.
+    
+    OUTPUT RULES
+    1) Preserve the original structure, order, and number of groups/items exactly.
+    2) Translate all group names and menu items into natural ${language}.
+    3) Do not add, remove, merge, split, or invent menu items.
+    4) Use familiar, student-friendly wording. Avoid overly literal translations.
+    5) Return only the translated menu in the same format as the input.
+    
+    GROUP NAMES
+    - Use natural cafeteria category names in ${language}, not word-for-word translations.
+    - For example, translate categories by function, such as plate lunches, bowls, value bowls,
+      or takeout/grab-and-go items.
+    
+    TRANSLATION STYLE
+    - Prefer clear, natural, and informal food descriptions over strict literal translation
+      when a literal translation would be confusing.
+    - For unfamiliar dish names, transliterate or keep the established dish name, then add a short explanation.
+    - When helpful, identify the main ingredient, cooking method, and defining sauce/flavor.
+    - Do not over-explain items that are already clear in ${language}.
+    
+    PARENTHESES
+    Add a short parenthetical description only when the dish would likely be unfamiliar or unclear to the target reader.
+    
+    Add parentheses when the item:
+    - Is not commonly recognized by native speakers of ${language} from the target student culture.
+    - Uses an unfamiliar cultural dish name, regional style, brand, place name, or specialized cooking term.
+    - Uses an English/American menu phrase whose meaning is not obvious from the words alone.
+    - Does not clearly show the main ingredient, dish type, sauce, or flavor.
+    - Is a salad, wrap, bowl, or plate item with an unclear style name such as "Black & Blue,"
+      "Mesquite," "Bruschetta," "Adobo," "Lau Lau," or "Kalua."
+    
+    Do not add parentheses when:
+    - The dish is likely familiar to the target reader.
+    - The translated name already identifies the dish clearly.
+    - The description would only repeat the name.
+    - There is not enough reliable information to describe it beyond the translated name.
+    
+    PARENTHESIS STYLE
+    - Write descriptions in ${language}.
+    - Keep them short: about 6 to 16 words.
+    - Describe the basic dish type, main ingredient, cooking method, sauce, or defining flavor.
+    - Be neutral and factual.
+    - Do not add marketing language.
+    - Do not use uncertainty phrases like "usually," "probably," or "may contain."
+    
+    INGREDIENT ACCURACY
+    - Do not invent restaurant-specific ingredients, sauces, toppings, sides, or preparation details.
+    - Only mention ingredients that appear in the name or are essential to the commonly recognized dish.
+    - If recipes vary, give only a broad description.
+    - You may mention the standard defining preparation of a well-known dish, such as fried cutlet,
+      slow-cooked pork, stewed beef, or vinegar-soy braise.
+    - Do not infer allergens, dietary labels, sides, or exact toppings when uncertain.
+    
+    SPECIAL CASES
+    - Keep brand names and proper nouns as-is unless there is an established translation.
+    - Keep style names like "Cajun," "Mesquite," "Black & Blue," or "Bruschetta" only if they are
+      understandable in ${language}; otherwise translate or explain the meaning.
+    - Transliterate unfamiliar cultural dish names when appropriate, then add a basic description.
+    - Preserve numbers, serving sizes, and established abbreviations.
+    - For fish names that may be unfamiliar, add a simple description such as "white fish" when accurate.
+    
+    EXAMPLES
+    Use these as meaning guides. In the actual output, write the names and descriptions naturally in ${language}.
+    
+    - "Country Fried Steak" → translated name + (breaded fried beef with creamy gravy)
+    - "Kalua Pork" → translated name + (Hawaiian-style slow-cooked shredded pork)
+    - "Lau Lau" → translated name + (Hawaiian dish steamed in leaves)
+    - "Pork Adobo" → translated name + (Filipino pork braised with vinegar and soy sauce)
+    - "Black & Blue Chicken Salad" → translated name + (spiced chicken salad with blue cheese)
+    - "Mesquite Chicken Salad" → translated name + (smoky-flavored chicken salad)
+    - "Furikake Swai" → translated name + (white fish seasoned with furikake)
+    - "Loco Moco" → translated name + (rice with hamburger patty, gravy, and egg)
+    - "Chicken Katsu" → translated name + (Japanese-style breaded fried chicken cutlet)
+    - "Bibimbap" → translated name + (Korean rice bowl with vegetables and mixed toppings)
+    - "Pork Lumpia" → translated name + (Filipino fried rolls filled with seasoned pork)
+    - "Teriyaki Chicken" → translated name + (Japanese-style teriyaki chicken)
+    
+    Return ONLY the translated menu text.\n`;
 
     const translatedMenu = await fetchOpenAI(
       prompt,


### PR DESCRIPTION
Rewrite manualTranslate to use ordered, rule-based substring replacements with helper functions and logging; simplify weekTwo handling and add manualTranslate tests. Replace inline regex literals in ccMenuParsing with RegExp constructors and tighten the embedded JSON PDF extraction; adjust related test formatting. Expand and clarify the menu translation prompt in menuActions for student-focused translations. Increase OpenAI client maxTokens from 8000 to 10000.