### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Manoa Menu is a single Next.js 16 (App Router) + Prisma 5 + PostgreSQL app. Standard scripts live in `package.json` (`dev`, `lint`, `test`, `build`) and CI is `.github/workflows/ci.yml` (lint + unit tests only). The notes below cover non-obvious setup/run caveats for this environment.
+
+### Services
+- **Next.js dev server** — `npm run dev` on http://localhost:3000. This is the whole product (UI + API routes).
+- **PostgreSQL** — required by Prisma for the app to run. Not required for `npm run lint` or `npm test`.
+
+### Environment
+- `.env` (gitignored) must exist with at least: `DATABASE_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, and `OPENAI_API_KEY`. In this environment `DATABASE_URL` points at the local Postgres `manoa_menu` DB.
+- **`OPENAI_API_KEY` must be set even just to load the menu API.** `src/app/utils/api/openai.ts` instantiates the OpenAI client at module load, so `/api/cc-menu` throws 500 on import if the var is missing — even for the cached English path, which never actually calls OpenAI. A placeholder value is enough to serve cached menus; a **real** key is only needed for live PDF parsing and translations.
+- `GW_API_URL` / `HA_API_URL` / `MMR_API_KEY` are optional and only power the Gateway / Hale Aloha (Sodexo) menus via `/api/sdx-menu`.
+
+### PostgreSQL notes
+- Start the server on a fresh boot: `sudo pg_ctlcluster 16 main start` (the service is not auto-enabled). Local superuser is `postgres` / password `postgres`, database `manoa_menu`.
+- **Do not use `prisma migrate deploy` / `migrate dev`.** The committed migration history is broken: both `20241203051933_original_user` and `20241207063142_m3` add the `FoodTable.likes` column, so migrations fail on a fresh DB with `column "likes" already exists`. Use `npx prisma db push` to sync the schema instead, then `npx prisma db seed` for default users.
+- Seeded accounts (password `changeme`): `admin@foo.com` (ADMIN), `john@foo.com` (USER).
+
+### Running / testing gotchas
+- Env var changes require restarting `npm run dev` (Next.js loads `.env` at startup).
+- The menu (`/api/cc-menu?language=English`) serves from the `CampusCenterMenus` DB cache when a row exists for the current `week_of` (see `getCurrentWeekOf`); otherwise it scrapes the live UH Sodexo site and calls OpenAI. To demo the UI without network/OpenAI, insert a `CampusCenterMenus` English row for the current week.
+- NextAuth is configured with a custom `pages.signIn` of `/auth/signin`, but that page is not implemented (returns 404). The NextAuth API routes under `/api/auth/*` do work.
+- Unit tests (`npm test`, `tsx --test src/lib/**/*.test.ts`) are pure logic and need no DB or network. E2E (`npx playwright test`) auto-starts the dev server via `playwright.config.ts` and requires Playwright browsers installed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the Manoa Menu app (Next.js 16 + Prisma 5 + PostgreSQL) and documents non-obvious setup/run caveats for future cloud agents.

The only committed change is a new `AGENTS.md`. Environment steps (npm install, PostgreSQL, `.env`, `prisma db push` + seed) were performed in the VM and captured via the update script / AGENTS.md; `.env` and `node_modules` remain gitignored.

## What was done
- Installed npm dependencies (`npm install`, Node LTS v22).
- Installed & started PostgreSQL 16; created `manoa_menu` DB.
- Created `.env` (`DATABASE_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, placeholder `OPENAI_API_KEY`).
- Synced schema with `npx prisma db push` (migration history is broken — `likes` column added twice) and seeded default users.
- Ran lint + unit tests and started the dev server.

## Verification
- ✅ `npm run lint` — clean
- ✅ `npm test` — 27/27 unit tests pass
- ✅ `npm run dev` — served the weekly Campus Center menu at http://localhost:3000

[manoa_menu_hello_world.mp4](https://cursor.com/agents/bc-9c68f151-ec12-4ba5-ab50-1801459587bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmanoa_menu_hello_world.mp4)

[Manoa Menu weekly menu rendered](https://cursor.com/agents/bc-9c68f151-ec12-4ba5-ab50-1801459587bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmanoa_menu_page.webp)

## Update script
```
npm install
npx prisma generate
```

See `AGENTS.md` → `## Cursor Cloud specific instructions` for PostgreSQL startup, the `prisma db push` (not `migrate`) caveat, and the `OPENAI_API_KEY`-required-at-import gotcha.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c68f151-ec12-4ba5-ab50-1801459587bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c68f151-ec12-4ba5-ab50-1801459587bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

