### PR TITLE
Preserve SDX day tab and hide placeholder items

### DIFF
--- a/src/app/api/sdx-menu/route.ts
+++ b/src/app/api/sdx-menu/route.ts
@@ -18,6 +18,7 @@ import {
   buildSdxTranslationMap,
   collectSdxTranslatableStrings,
 } from '@/lib/sdxTranslation';
+import { isSdxPlaceholderItemName } from '@/lib/sdxSpecialHours';
 
 const SUPPORTED_LANGUAGES = ['english', 'japanese', 'korean', 'chinese'];
 
@@ -71,11 +72,6 @@ SPECIAL CASES
 Return ONLY the JSON object with the translations array.\n`
 );
 
-const isPlaceholderItemName = (formalName: string | null | undefined): boolean => {
-  const normalized = (formalName || '').trim().toLowerCase();
-  return !normalized || normalized === 'have a nice day';
-};
-
 const removeNutritionalFacts = (rootObject: SodexoMeal): FilteredSodexoMeal => ({
   name: rootObject.name,
   groups: rootObject.groups
@@ -83,7 +79,7 @@ const removeNutritionalFacts = (rootObject: SodexoMeal): FilteredSodexoMeal => (
       name: (group.name || '').trim(),
       items: group.items
         // Drop placeholders / blank names first so empty groups can be removed below
-        .filter((item) => !isPlaceholderItemName(item.formalName))
+        .filter((item) => !isSdxPlaceholderItemName(item.formalName))
         .map((item) => {
           // Remove nutritional facts from items
           const {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -460,7 +460,8 @@ const Page = () => {
     </Box>
   );
 
-  const menuContentKey = `${menuState}-${language}`;
+  // Key by location only — including language remounted the menu and reset the day tab.
+  const menuContentKey = menuState;
   const hasDisplayableMenu = (() => {
     switch (menuState) {
       case 'cc':

--- a/src/components/SdxMenu.tsx
+++ b/src/components/SdxMenu.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FilteredSodexoMeal, SdxAPIResponse } from '@/types/menuTypes';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -19,20 +19,27 @@ import Tooltip from '@mui/material/Tooltip';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { formatSdxDayTabTitle, isFav } from '@/lib/menuHelper';
 import { getCurrentDayOf } from '@/lib/dateFunctions';
+import {
+  isSdxPlaceholderItemName,
+  sdxDayHasVisibleMeals,
+  sdxMealHasVisibleItems,
+} from '@/lib/sdxSpecialHours';
 import StarButton from '@/components/StarButton';
 import { menuDayTabFadeSx, getMenuDayTabsScrollSx, menuDayTabsDesktopSx } from '@/components/menuDayTabStyles';
 import { useMenuDayTabScrollFades } from '@/components/useMenuDayTabScrollFades';
 
-const mealHasVisibleItems = (meal: FilteredSodexoMeal): boolean => (
-  meal.groups.some((group) => (
-    group.name.trim().length > 0
-    && group.items.some((item) => item.formalName.trim().length > 0)
-  ))
-);
+/** Survives brief unmounts (e.g. loading spinner) so language switches keep the selected day. */
+let persistedSdxActiveDay: string | null = null;
 
-const dayHasVisibleMeals = (dayMenu: SdxAPIResponse): boolean => (
-  dayMenu.meals.some(mealHasVisibleItems)
-);
+const resolveSdxActiveDay = (
+  availableDates: string[],
+  preferred: string | null,
+  today: string,
+): string => {
+  if (preferred && availableDates.includes(preferred)) return preferred;
+  if (availableDates.includes(today)) return today;
+  return availableDates[0] ?? today;
+};
 
 interface SdxMenuProps {
   weekMenu: SdxAPIResponse[];
@@ -105,6 +112,26 @@ const SdxMenu: React.FC<SdxMenuProps> = ({ weekMenu, language, favArr = [], user
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   const [favArray, setFavArray] = useState(favArr);
+  const visibleDays = weekMenu.filter(sdxDayHasVisibleMeals);
+  const availableDates = visibleDays.map((day) => day.date);
+
+  const [activeDay, setActiveDay] = useState(() => (
+    resolveSdxActiveDay(availableDates, persistedSdxActiveDay, currentDateOf)
+  ));
+
+  useEffect(() => {
+    const dates = weekMenu.filter(sdxDayHasVisibleMeals).map((day) => day.date);
+    if (dates.length === 0) return;
+    const next = resolveSdxActiveDay(
+      dates,
+      persistedSdxActiveDay ?? activeDay,
+      currentDateOf,
+    );
+    if (next !== activeDay) {
+      setActiveDay(next);
+    }
+    persistedSdxActiveDay = next;
+  }, [weekMenu, activeDay, currentDateOf]);
 
   const handleToggle = (item: string) => {
     const updatedFavArr = (prevFavArray: string[]) => {
@@ -116,9 +143,20 @@ const SdxMenu: React.FC<SdxMenuProps> = ({ weekMenu, language, favArr = [], user
     setFavArray(updatedFavArr);
   };
 
-  const { tabsRef, canScrollLeft, canScrollRight, tabsOverflow } = useMenuDayTabScrollFades(weekMenu);
+  const handleDaySelect = (key: string | null) => {
+    if (!key) return;
+    persistedSdxActiveDay = key;
+    setActiveDay(key);
+  };
+
+  const { tabsRef, canScrollLeft, canScrollRight, tabsOverflow } = useMenuDayTabScrollFades(visibleDays);
+  const showCategoryLabels = language.toLowerCase() === 'english';
 
   const scrollFadeOverlaySx = menuDayTabFadeSx;
+
+  if (visibleDays.length === 0) {
+    return null;
+  }
 
   return (
     <Box sx={{ mt: { xs: 1.25, sm: 0 }, width: '100%', maxWidth: '100%', minWidth: 0 }}>
@@ -143,14 +181,14 @@ const SdxMenu: React.FC<SdxMenuProps> = ({ weekMenu, language, favArr = [], user
         </Box>
         <Tabs
           variant="underline"
-          defaultActiveKey={currentDateOf}
+          activeKey={activeDay}
+          onSelect={handleDaySelect}
           id="menuDateTabs"
           className="mb-2"
         >
-        {weekMenu
-          .filter(dayHasVisibleMeals)
+        {visibleDays
           .map((dayMenu) => {
-            const visibleMeals = dayMenu.meals.filter(mealHasVisibleItems);
+            const visibleMeals = dayMenu.meals.filter(sdxMealHasVisibleItems);
 
             const getGridItemSize = (mealCount: number) => {
               switch (mealCount) {
@@ -164,36 +202,6 @@ const SdxMenu: React.FC<SdxMenuProps> = ({ weekMenu, language, favArr = [], user
                   return { xs: 12, md: 12, lg: 4, xl: 3 };
                 default:
                   return { xs: 12, md: 12, lg: 4, xl: 4 };
-              }
-            };
-
-            const getScrollProperties = (mealCount: number) => {
-              switch (mealCount) {
-                case 1:
-                  return {
-                    maxHeight: { xs: 'none', md: 'none', lg: 'none' as const },
-                    overflow: { xs: 'visible', md: 'visible', lg: 'visible' as const },
-                  };
-                case 2:
-                  return {
-                    maxHeight: { xs: 'none', md: 'none', lg: 820 },
-                    overflow: { xs: 'visible', md: 'visible', lg: 'auto' as const },
-                  };
-                case 3:
-                  return {
-                    maxHeight: { xs: 'none', md: 'none', lg: 840 },
-                    overflow: { xs: 'visible', md: 'visible', lg: 'auto' as const },
-                  };
-                case 4:
-                  return {
-                    maxHeight: { xs: 'none', md: 'none', lg: 840 },
-                    overflow: { xs: 'visible', md: 'visible', lg: 'auto' as const },
-                  };
-                default:
-                  return {
-                    maxHeight: { xs: 'none', md: 'none', lg: 840 },
-                    overflow: { xs: 'visible', md: 'visible', lg: 'auto' as const },
-                  };
               }
             };
 
@@ -213,14 +221,10 @@ const SdxMenu: React.FC<SdxMenuProps> = ({ weekMenu, language, favArr = [], user
                   {visibleMeals.map((meal: FilteredSodexoMeal, mealIndex) => (
                     <Grid size={gridItemSize} key={`${meal.name}-${mealIndex}`}>
                       <Card
-                        className="custom-scrollbar"
                         elevation={isMobile ? 0 : undefined}
                         sx={{
                           m: isMobile ? 0 : 2,
                           height: '100%',
-                          ...(isMobile
-                            ? { maxHeight: 'none', overflow: 'visible' }
-                            : getScrollProperties(visibleMeals.length)),
                           borderRadius: isMobile ? 0 : undefined,
                           animation: 'fadeIn 0.3s ease-in',
                           '@keyframes fadeIn': {
@@ -253,7 +257,7 @@ const SdxMenu: React.FC<SdxMenuProps> = ({ weekMenu, language, favArr = [], user
                           </Box>
                         ) : (
                           <CardHeader className="px-3 py-2" style={{ backgroundColor: '#ECECEC' }}>
-                            <Typography variant="h4">
+                            <Typography variant="h5">
                               {meal.name}
                             </Typography>
                           </CardHeader>
@@ -268,25 +272,27 @@ const SdxMenu: React.FC<SdxMenuProps> = ({ weekMenu, language, favArr = [], user
                           {meal.groups
                             .filter((group) => (
                               group.name.trim().length > 0
-                              && group.items.some((item) => item.formalName.trim().length > 0)
+                              && group.items.some((item) => !isSdxPlaceholderItemName(item.formalName))
                             ))
                             .map((group, groupIndex) => (
                             <Box key={`${group.name}-${groupIndex}`} sx={{ mb: isMobile ? 1 : 1.5 }}>
-                              <Typography
-                                variant={isMobile ? 'overline' : 'h6'}
-                                sx={{
-                                  display: 'block',
-                                  mb: isMobile ? 0.5 : 1,
-                                  fontWeight: 700,
-                                  color: 'text.secondary',
-                                  letterSpacing: '0.08em',
-                                }}
-                              >
-                                {group.name}
-                              </Typography>
+                              {showCategoryLabels && (
+                                <Typography
+                                  variant={isMobile ? 'overline' : 'h6'}
+                                  sx={{
+                                    display: 'block',
+                                    mb: isMobile ? 0.5 : 1,
+                                    fontWeight: 700,
+                                    color: 'text.secondary',
+                                    letterSpacing: '0.08em',
+                                  }}
+                                >
+                                  {group.name}
+                                </Typography>
+                              )}
                               <Box component="ul" sx={{ listStyle: 'none', m: 0, p: 0 }}>
                                 {group.items
-                                  .filter((item) => item.formalName.trim().length > 0)
+                                  .filter((item) => !isSdxPlaceholderItemName(item.formalName))
                                   .map((item, itemIndex) => (
                                   <Box
                                     component="li"

--- a/src/components/SdxMenu.tsx
+++ b/src/components/SdxMenu.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { FilteredSodexoMeal, SdxAPIResponse } from '@/types/menuTypes';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -115,23 +114,8 @@ const SdxMenu: React.FC<SdxMenuProps> = ({ weekMenu, language, favArr = [], user
   const visibleDays = weekMenu.filter(sdxDayHasVisibleMeals);
   const availableDates = visibleDays.map((day) => day.date);
 
-  const [activeDay, setActiveDay] = useState(() => (
-    resolveSdxActiveDay(availableDates, persistedSdxActiveDay, currentDateOf)
-  ));
-
-  useEffect(() => {
-    const dates = weekMenu.filter(sdxDayHasVisibleMeals).map((day) => day.date);
-    if (dates.length === 0) return;
-    const next = resolveSdxActiveDay(
-      dates,
-      persistedSdxActiveDay ?? activeDay,
-      currentDateOf,
-    );
-    if (next !== activeDay) {
-      setActiveDay(next);
-    }
-    persistedSdxActiveDay = next;
-  }, [weekMenu, activeDay, currentDateOf]);
+  const [selectedDay, setSelectedDay] = useState<string | null>(() => persistedSdxActiveDay);
+  const activeDay = resolveSdxActiveDay(availableDates, selectedDay, currentDateOf);
 
   const handleToggle = (item: string) => {
     const updatedFavArr = (prevFavArray: string[]) => {
@@ -146,7 +130,7 @@ const SdxMenu: React.FC<SdxMenuProps> = ({ weekMenu, language, favArr = [], user
   const handleDaySelect = (key: string | null) => {
     if (!key) return;
     persistedSdxActiveDay = key;
-    setActiveDay(key);
+    setSelectedDay(key);
   };
 
   const { tabsRef, canScrollLeft, canScrollRight, tabsOverflow } = useMenuDayTabScrollFades(visibleDays);

--- a/src/lib/sdxSpecialHours.test.ts
+++ b/src/lib/sdxSpecialHours.test.ts
@@ -111,6 +111,36 @@ describe('isSdxMenuBlank', () => {
   it('detects empty week menus', () => {
     assert.equal(isSdxMenuBlank([]), true);
     assert.equal(isSdxMenuBlank([{ meals: [] }, { meals: [] }]), true);
-    assert.equal(isSdxMenuBlank([{ meals: [{ name: 'Lunch', groups: [] }] }]), false);
+    assert.equal(isSdxMenuBlank([{ meals: [{ groups: [] }] }]), true);
+  });
+
+  it('treats placeholder-only menus as blank', () => {
+    assert.equal(isSdxMenuBlank([{
+      meals: [{
+        groups: [{
+          name: 'Entrees',
+          items: [{ formalName: 'Have A Nice Day' }],
+        }],
+      }],
+    }]), true);
+    assert.equal(isSdxMenuBlank([{
+      meals: [{
+        groups: [{
+          name: 'Entrees',
+          items: [{ formalName: '  ' }],
+        }],
+      }],
+    }]), true);
+  });
+
+  it('detects menus with real items', () => {
+    assert.equal(isSdxMenuBlank([{
+      meals: [{
+        groups: [{
+          name: 'Entrees',
+          items: [{ formalName: 'Garlic Chicken' }],
+        }],
+      }],
+    }]), false);
   });
 });

--- a/src/lib/sdxSpecialHours.ts
+++ b/src/lib/sdxSpecialHours.ts
@@ -267,9 +267,32 @@ export function parseSdxSpecialHours(html: string, now = new Date()): SdxSpecial
   return normalizeSeasonalHours(active[active.length - 1]);
 }
 
-export function isSdxMenuBlank(weekMenu: { meals?: unknown[] }[] | null | undefined): boolean {
+/** Sodexo placeholder / closed-day item names that should not count as real menu content. */
+export function isSdxPlaceholderItemName(formalName: string | null | undefined): boolean {
+  const normalized = (formalName || '').trim().toLowerCase();
+  return !normalized || normalized === 'have a nice day';
+}
+
+type SdxVisibleItem = { formalName?: string | null };
+type SdxVisibleGroup = { name?: string | null; items?: SdxVisibleItem[] | null };
+type SdxVisibleMeal = { groups?: SdxVisibleGroup[] | null };
+
+export function sdxMealHasVisibleItems(meal: SdxVisibleMeal | null | undefined): boolean {
+  if (!meal?.groups?.length) return false;
+  return meal.groups.some((group) => (
+    Boolean(group?.name?.trim())
+    && (group.items ?? []).some((item) => !isSdxPlaceholderItemName(item?.formalName))
+  ));
+}
+
+export function sdxDayHasVisibleMeals(day: { meals?: SdxVisibleMeal[] | null } | null | undefined): boolean {
+  return (day?.meals ?? []).some(sdxMealHasVisibleItems);
+}
+
+/** True when the week has no real food items (empty days, empty groups, or placeholders only). */
+export function isSdxMenuBlank(weekMenu: { meals?: SdxVisibleMeal[] | null }[] | null | undefined): boolean {
   if (!weekMenu || weekMenu.length === 0) {
     return true;
   }
-  return weekMenu.every((day) => !day.meals || day.meals.length === 0);
+  return !weekMenu.some(sdxDayHasVisibleMeals);
 }


### PR DESCRIPTION
Refactors SDX menu visibility logic into shared helpers, including placeholder-item detection, meal/day visibility checks, and stricter blank-menu detection for placeholder-only data. Updates API/menu rendering to reuse those helpers, filters non-displayable days/items consistently, and keeps the selected SDX day tab stable across language changes by avoiding menu remounts.